### PR TITLE
Divide jobs and job_times tables and a few improvements

### DIFF
--- a/lib/App/Koyomi/DataSource/Job/Teng.pm
+++ b/lib/App/Koyomi/DataSource/Job/Teng.pm
@@ -8,6 +8,7 @@ use Class::Accessor::Lite (
 );
 use Smart::Args;
 
+use App::Koyomi::DataSource::Job::Teng::Data;
 use App::Koyomi::DataSource::Job::Teng::Object;
 use App::Koyomi::DataSource::Job::Teng::Schema;
 
@@ -40,9 +41,26 @@ sub instance {
 }
 
 sub gets {
-    my $self = shift;
-    my $itr = $self->teng->search('jobs' => +{});
-    return $itr->all;
+    args(
+        my $self,
+        my $ctx => 'App::Koyomi::Context',
+    );
+
+    my @jobs  = $self->teng->search('jobs'      => +{})->all;
+    my @times = $self->teng->search('job_times' => +{})->all;
+
+    my @data;
+    for my $job (@jobs) {
+        my @_t = grep { $_->job_id == $job->id } @times;
+        my $d  = App::Koyomi::DataSource::Job::Teng::Data->new(
+            ctx   => $ctx,
+            job   => $job,
+            times => \@_t,
+        );
+        push(@data, $d);
+    }
+
+    return @data;
 }
 
 1;

--- a/lib/App/Koyomi/DataSource/Job/Teng/Data.pm
+++ b/lib/App/Koyomi/DataSource/Job/Teng/Data.pm
@@ -1,0 +1,86 @@
+package App::Koyomi::DataSource::Job::Teng::Data;
+
+use strict;
+use warnings;
+use 5.010_001;
+use Class::Accessor::Lite (
+    ro => [qw/ctx times/],
+);
+use Smart::Args;
+
+use version; our $VERSION = 'v0.1.4';
+
+# Accessor for jobs.columns
+{
+    no strict 'refs';
+    for my $column (qw/id user command memo/) {
+        *{ __PACKAGE__ . '::' . $column } = sub {
+            my $self = shift;
+            $self->{_job}->$column;
+        };
+    }
+    # DATETIME => DateTime
+    for my $column (qw/created_on updated_at/) {
+        *{ __PACKAGE__ . '::' . $column } = sub {
+            my $self = shift;
+            DateTime::Format::MySQL->parse_datetime($self->{_job}->$column)
+                ->set_time_zone($self->ctx->config->time_zone);
+        };
+    }
+}
+
+sub new {
+    args(
+        my $class,
+        my $ctx   => 'App::Koyomi::Context',
+        my $job   => 'Teng::Row',
+        my $times => 'ArrayRef[Teng::Row]',
+    );
+    bless +{
+        _job  => $job,
+        times => $times,
+        ctx   => $ctx,
+    }, $class;
+}
+
+1;
+__END__
+
+=encoding utf-8
+
+=head1 NAME
+
+App::Koyomi::DataSource::Job::Teng::Data - Wrapper class to represents a record of job datasource
+
+=head1 SYNOPSIS
+
+    use App::Koyomi::DataSource::Job::Teng::Data;
+    my $data = App::Koyomi::DataSource::Job::Teng::Data->new(
+        ctx   => $ctx,   # App::Koyomi::Context
+        job   => $job,   # Teng::Row (`jobs` table)
+        times => $times, # ArrayRef[Teng::Row] (`job_times` table)
+    );
+
+=head1 DESCRIPTION
+
+Wrapper class of I<Teng::Row> for job datasource.
+
+=head1 SEE ALSO
+
+L<App::Koyomi::DataSource::Job::Teng>,
+L<Teng::Row>
+
+=head1 AUTHORS
+
+YASUTAKE Kiyoshi E<lt>yasutake.kiyoshi@gmail.comE<gt>
+
+=head1 LICENSE
+
+Copyright (C) 2015 YASUTAKE Kiyoshi.
+
+This library is free software; you can redistribute it and/or modify it under
+the same terms as Perl itself.  That means either (a) the GNU General Public
+License or (b) the Artistic License.
+
+=cut
+

--- a/lib/App/Koyomi/DataSource/Job/Teng/Schema.pm
+++ b/lib/App/Koyomi/DataSource/Job/Teng/Schema.pm
@@ -12,7 +12,13 @@ use version; our $VERSION = 'v0.1.4';
 table {
     name    'jobs';
     pk      'id';
-    columns @App::Koyomi::Job::FIELDS;
+    columns @App::Koyomi::Job::JOB_FIELDS;
+};
+
+table {
+    name    'job_times';
+    pk      'job_id';
+    columns @App::Koyomi::Job::TIME_FIELDS;
 };
 
 1;

--- a/lib/App/Koyomi/Schedule.pm
+++ b/lib/App/Koyomi/Schedule.pm
@@ -66,13 +66,25 @@ sub get_jobs {
 sub _filter_current_jobs {
     my ($all_jobs, $now) = @_;
 
+    my @matched;
+    for my $job (@$all_jobs) {
+        if ( _filter_job_times($job->times, $now) ) {
+            push(@matched, $job);
+        }
+    }
+    return @matched;
+}
+
+sub _filter_job_times {
+    my ($times, $now) = @_;
+
     # all conditions but day and day-of-week
     my @jobs = grep {
            ( $_->year   eq '*' || $_->year   == $now->year   )
         && ( $_->month  eq '*' || $_->month  == $now->month  )
         && ( $_->hour   eq '*' || $_->hour   == $now->hour   )
         && ( $_->minute eq '*' || $_->minute == $now->minute )
-    } @$all_jobs;
+    } @$times;
 
     # day and day-of-week conditions
     @jobs = grep {

--- a/lib/App/Koyomi/Schedule.pm
+++ b/lib/App/Koyomi/Schedule.pm
@@ -44,14 +44,21 @@ sub update {
     }
 
     debugf('update schedule');
-    $self->_update_jobs;
-    $self->last_updated_at($now->epoch);
+    $self->_update_jobs && $self->last_updated_at($now->epoch);
     #debugf(ddf($self->jobs));
 }
 
 sub _update_jobs {
     my $self = shift;
-    $self->{jobs} = App::Koyomi::Job->get_jobs(ctx => $self->ctx);
+    my $jobs = eval {
+        App::Koyomi::Job->get_jobs(ctx => $self->ctx);
+    };
+    if ($@) {
+        critf('FAILED to fetch jobs!! ERROR = %s', $@);
+        return 0;
+    }
+    $self->{jobs} = $jobs;
+    return 1;
 }
 
 sub get_jobs {

--- a/lib/App/Koyomi/Semaphore.pm
+++ b/lib/App/Koyomi/Semaphore.pm
@@ -35,8 +35,8 @@ sub consume {
     }
 
     my $ttl = $ctx->config->{job}{lock_ttl_seconds};
+    debugf(q/now:%d semaphore:%d diff:%d/, $now->epoch, $semaphore->run_date->epoch, $now->epoch - $semaphore->run_date->epoch);
     if ($now->epoch - $semaphore->run_date->epoch < $ttl) {
-        debugf(q/now:%d semaphore:%d diff:%d/, $now->epoch, $semaphore->run_date->epoch, $now->epoch - $semaphore->run_date->epoch);
         debugf(
             q/%s run on another proc. Host=%s, Pid=%d, Run_On='%s'/,
             $header, $semaphore->run_host, $semaphore->run_pid, $semaphore->run_date->datetime

--- a/schema/koyomi.ddl
+++ b/schema/koyomi.ddl
@@ -16,6 +16,36 @@
 /*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
 
 --
+-- Table structure for table `job_times`
+--
+
+DROP TABLE IF EXISTS `job_times`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `job_times` (
+  `job_id` int(10) unsigned NOT NULL,
+  `year` varchar(4) NOT NULL DEFAULT '*' COMMENT 'Ex) 2015',
+  `month` varchar(2) NOT NULL DEFAULT '*' COMMENT 'Ex) 3, 12',
+  `day` varchar(2) NOT NULL DEFAULT '*' COMMENT 'Day in month. Ex) 2, 31',
+  `hour` varchar(2) NOT NULL DEFAULT '*' COMMENT 'Hour in day. Ex) 0, 12, 23',
+  `minute` varchar(2) NOT NULL DEFAULT '*' COMMENT 'Ex) 0, 59',
+  `weekday` varchar(1) NOT NULL DEFAULT '*' COMMENT 'Day of week as number. Compatiable with crontab. Ex) 0, 6, 7',
+  `created_on` datetime NOT NULL,
+  `updated_at` datetime NOT NULL,
+  PRIMARY KEY (`job_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `job_times`
+--
+
+LOCK TABLES `job_times` WRITE;
+/*!40000 ALTER TABLE `job_times` DISABLE KEYS */;
+/*!40000 ALTER TABLE `job_times` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
 -- Table structure for table `jobs`
 --
 
@@ -27,17 +57,20 @@ CREATE TABLE `jobs` (
   `user` varchar(32) NOT NULL DEFAULT '' COMMENT 'Command executor in the system',
   `command` varchar(4096) NOT NULL COMMENT 'Shell command to execute',
   `memo` varchar(512) NOT NULL DEFAULT '',
-  `year` varchar(4) NOT NULL DEFAULT '*' COMMENT 'Ex) 2015',
-  `month` varchar(2) NOT NULL DEFAULT '*' COMMENT 'Ex) 3, 12',
-  `day` varchar(2) NOT NULL DEFAULT '*' COMMENT 'Day in month. Ex) 2, 31',
-  `hour` varchar(2) NOT NULL DEFAULT '*' COMMENT 'Hour in day. Ex) 0, 12, 23',
-  `minute` varchar(2) NOT NULL DEFAULT '*' COMMENT 'Ex) 0, 59',
-  `weekday` varchar(1) NOT NULL DEFAULT '*' COMMENT 'Day of week as number. Compatiable with crontab. Ex) 0, 6, 7',
   `created_on` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `jobs`
+--
+
+LOCK TABLES `jobs` WRITE;
+/*!40000 ALTER TABLE `jobs` DISABLE KEYS */;
+/*!40000 ALTER TABLE `jobs` ENABLE KEYS */;
+UNLOCK TABLES;
 
 --
 -- Table structure for table `semaphores`
@@ -51,12 +84,21 @@ CREATE TABLE `semaphores` (
   `number` smallint(5) unsigned NOT NULL COMMENT 'Semaphore resource remains (Not in use)',
   `run_host` varchar(256) NOT NULL DEFAULT '' COMMENT 'On which host the last job ran',
   `run_pid` int(10) unsigned NOT NULL DEFAULT '0' COMMENT 'Tha last process id',
-  `created_on` datetime NOT NULL,
   `run_date` datetime NOT NULL,
+  `created_on` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   PRIMARY KEY (`job_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `semaphores`
+--
+
+LOCK TABLES `semaphores` WRITE;
+/*!40000 ALTER TABLE `semaphores` DISABLE KEYS */;
+/*!40000 ALTER TABLE `semaphores` ENABLE KEYS */;
+UNLOCK TABLES;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 
 /*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
@@ -67,4 +109,4 @@ CREATE TABLE `semaphores` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2015-05-10 20:16:32
+-- Dump completed on 2015-05-30  0:47:08

--- a/t/App/Koyomi/Schedule/_filter_job_times.t
+++ b/t/App/Koyomi/Schedule/_filter_job_times.t
@@ -5,7 +5,7 @@ use DateTime;
 use Time::Piece;
 
 use App::Koyomi::Schedule;
-use Test::Koyomi::Job;
+use Test::Koyomi::JobTime;
 
 plan tests => 1 * blocks;
 
@@ -19,12 +19,12 @@ run {
     my $block = shift;
 
     my @job_date = split(/ /, $block->job_date);
-    my $job = Test::Koyomi::Job->mock(@job_date);
+    my $job = Test::Koyomi::JobTime->mock(@job_date);
 
     my $now_t = Time::Piece->strptime($block->executed_on, '%Y-%m-%dT%H:%M');
     my $now = DateTime->from_epoch(epoch => $now_t->epoch);
 
-    my @jobs = App::Koyomi::Schedule::_filter_current_jobs([$job], $now);
+    my @jobs = App::Koyomi::Schedule::_filter_job_times([$job], $now);
 
     diag sprintf q{Job: '%s/%s/%s %s:%s (%s)', Now: '%s'}, @job_date, $block->executed_on;
 

--- a/t/lib/Test/Koyomi/JobTime.pm
+++ b/t/lib/Test/Koyomi/JobTime.pm
@@ -1,4 +1,4 @@
-package Test::Koyomi::Job;
+package Test::Koyomi::JobTime;
 
 use strict;
 use warnings;
@@ -10,7 +10,7 @@ use App::Koyomi::Job;
 
 use version; our $VERSION = 'v0.1.0';
 
-Class::Accessor::Lite->mk_ro_accessors(@App::Koyomi::Job::FIELDS);
+Class::Accessor::Lite->mk_ro_accessors(@App::Koyomi::Job::TIME_FIELDS);
 
 sub mock {
     args_pos(
@@ -40,11 +40,11 @@ __END__
 
 =head1 NAME
 
-B<Test::Koyomi::Job> - koyomi job test module
+B<Test::Koyomi::JobTime> - koyomi job test module
 
 =head1 SYNOPSIS
 
-    use Test::Koyomi::Job;
+    use Test::Koyomi::JobTime;
 
 =head1 DESCRIPTION
 
@@ -56,7 +56,7 @@ This module is for test about job.
 
 =item B<mock>
 
-Create mock job object.
+Create mock job time object.
 
 =back
 


### PR DESCRIPTION
As I announced at [Documentation Site](http://key-amb.github.io/App-Koyomi-Doc/about/), I divide "job timetable" from job entity.
I split previous _jobs_ table into following two tables:

- _jobs_ - job's basic data such as "user", "command" and so on.
- _job_times_ - job's timetable

And following improvement is included in this PR:

- Add "eval" block on updating jobs so that _koyomi worker_ won't die with sudden death of Job DataSource. To utilize this improvement, you should divide location of semaphore datasource from jobs datasource.