### PR TITLE
Implement "koyomi-cli delete" to delete jobs

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -9,6 +9,7 @@ requires 'Perl6::Slurp', '0.051005';
 requires 'Smart::Args', '0.12';
 requires 'TOML', '0.96';
 requires 'Text::ASCIITable', '0.20';
+requires 'Text::Diff', '1.41';
 requires 'Teng', '0.28';
 requires 'YAML::XS', '0.54';
 

--- a/cpanfile.snapshot
+++ b/cpanfile.snapshot
@@ -1,5 +1,12 @@
 # carton snapshot format: version 1.0
 DISTRIBUTIONS
+  Algorithm-Diff-1.1903
+    pathname: T/TY/TYEMQ/Algorithm-Diff-1.1903.tar.gz
+    provides:
+      Algorithm::Diff 1.1903
+      Algorithm::Diff::_impl 1.1903
+    requirements:
+      ExtUtils::MakeMaker 0
   B-Hooks-EndOfScope-0.15
     pathname: E/ET/ETHER/B-Hooks-EndOfScope-0.15.tar.gz
     provides:
@@ -1887,6 +1894,17 @@ DISTRIBUTIONS
       Encode 0
       List::Util 0
       perl v5.6.0
+  Text-Diff-1.41
+    pathname: O/OV/OVID/Text-Diff-1.41.tar.gz
+    provides:
+      Text::Diff 1.41
+      Text::Diff::Base 1.41
+      Text::Diff::Config 1.41
+      Text::Diff::Table 1.41
+    requirements:
+      Algorithm::Diff 1.19
+      Exporter 0
+      ExtUtils::MakeMaker 0
   Tie-IxHash-1.23
     pathname: C/CH/CHORNY/Tie-IxHash-1.23.tar.gz
     provides:

--- a/lib/App/Koyomi/CLI.pm
+++ b/lib/App/Koyomi/CLI.pm
@@ -13,6 +13,7 @@ use Log::Minimal env_debug => 'KOYOMI_LOG_DEBUG';
 use Perl6::Slurp;
 use Smart::Args;
 use Text::ASCIITable;
+use Text::Diff ();
 use YAML::XS ();
 
 use App::Koyomi::Context;
@@ -150,6 +151,9 @@ sub modify {
     unlink $tempfile;
 
     my $new_data = YAML::XS::Load($new_yaml);
+    $new_yaml = YAML::XS::Dump($new_data);
+    print Text::Diff::diff(\$yaml, \$new_yaml, +{ STYLE => 'Unified', CONTEXT => 5 });
+
     my @new_times = map { str2time($_) } @{$new_data->{times}};
     $new_data->{times} = \@new_times;
 

--- a/lib/App/Koyomi/CLI.pm
+++ b/lib/App/Koyomi/CLI.pm
@@ -21,7 +21,7 @@ use App::Koyomi::JobTime::Object;
 
 use version; our $VERSION = 'v0.3.2';
 
-my @CLI_METHODS = qw/add list modify delete/;
+my @CLI_METHODS = qw/help man add list modify delete/;
 
 sub new {
     my $class = shift;

--- a/lib/App/Koyomi/CLI.pm
+++ b/lib/App/Koyomi/CLI.pm
@@ -72,6 +72,7 @@ sub add {
 
     my ($fh, $tempfile) = tempfile();
     print $fh $yaml;
+    print $fh _yaml_description();
     close $fh;
     system($editor, $tempfile);
     my $new_yaml = slurp($tempfile);
@@ -141,6 +142,7 @@ sub modify {
 
     my ($fh, $tempfile) = tempfile();
     print $fh $yaml;
+    print $fh _yaml_description();
     close $fh;
     system($editor, $tempfile);
     my $new_yaml = slurp($tempfile);
@@ -160,6 +162,22 @@ sub modify {
     );
 
     infof('[modify] Finished.');
+}
+
+sub _yaml_description {
+    state $desc = <<'EOS';
+
+# __EOF__
+# Format and Description:
+#   "command": String. Job as shell command to execute.
+#   "memo":    String. You can add comment about the job on this field.
+#   "times":   Array. Each entry follows this format:
+#     - 'YYYY/mm/dd HH:MM (number of day in week)'
+#     Examples:
+#       - '2015/*/* 0:0 (7)' ... At 0:00 am every sunday in 2015
+#       - '*/*/* *:30 (*)'   ... At 30 minutes after every o'clock
+#   "user": String. OS user to execute the command. Leave it blank to execute by the user of worker
+EOS
 }
 
 1;

--- a/lib/App/Koyomi/CLI.pm
+++ b/lib/App/Koyomi/CLI.pm
@@ -79,10 +79,11 @@ sub add {
     unlink $tempfile;
 
     my $new_data = YAML::XS::Load($new_yaml);
+    print YAML::XS::Dump($new_data) . "\n";
     my @new_times = map { str2time($_) } @{$new_data->{times}};
     $new_data->{times} = \@new_times;
 
-    if (prompt('Add a job. OK? (y/n)', 'n') ne 'y') {
+    if (prompt('Add this job. OK? (y/n)', 'n') ne 'y') {
         infof('[add] Canceled.');
         return;
     }

--- a/lib/App/Koyomi/DataSource/Job.pm
+++ b/lib/App/Koyomi/DataSource/Job.pm
@@ -12,6 +12,7 @@ sub gets         { croak 'Must implement in child class!'; }
 sub get_by_id    { croak 'Must implement in child class!'; }
 sub create       { croak 'Must implement in child class!'; }
 sub update_by_id { croak 'Must implement in child class!'; }
+sub delete_by_id { croak 'Must implement in child class!'; }
 
 1;
 
@@ -33,6 +34,7 @@ B<App::Koyomi::DataSource::Job> - Abstract datasource class for job entity
     sub get_by_id { ... }
     sub create { ... }
     sub update_by_id { ... }
+    sub delete_by_id { ... }
 
 =head1 DESCRIPTION
 
@@ -62,6 +64,10 @@ Create one job data including job_times data.
 =item B<update_by_id>
 
 Update one job data including job_times data.
+
+=item B<delete_by_id>
+
+Delete one job data including job_times data.
 
 =back
 

--- a/lib/App/Koyomi/DataSource/Job/Teng.pm
+++ b/lib/App/Koyomi/DataSource/Job/Teng.pm
@@ -149,13 +149,14 @@ sub update_by_id {
         # update jobs
         my %job = map { $_ => $data->{$_} } qw/user command memo/;
         $job{updated_at} = $now_db;
-        my $updated = $teng->update('jobs', \%job, +{ id => $id });
-        unless ($updated) {
+        unless ($teng->update('jobs', \%job, +{ id => $id })) {
             croakf(q/Update jobs Failed! id=%d, data=%s/, $id, ddf(\%job));
         }
 
         # replace job_times
-        $teng->delete('job_times', +{ job_id => $id });
+        unless ($teng->delete('job_times', +{ job_id => $id })) {
+            croakf(q/Delete job_times Failed! id=%d/, $id);
+        }
         for my $t (@{$data->{times}}) {
             my %time = (
                 job_id => $id,

--- a/lib/App/Koyomi/DataSource/Job/Teng.pm
+++ b/lib/App/Koyomi/DataSource/Job/Teng.pm
@@ -18,14 +18,14 @@ use parent qw(App::Koyomi::DataSource::Job);
 
 use version; our $VERSION = 'v0.3.2';
 
-my $JOB;
+my $DATASOURCE;
 
 sub instance {
     args(
         my $class,
         my $ctx => 'App::Koyomi::Context',
     );
-    $JOB //= sub {
+    $DATASOURCE //= sub {
         my $connector
             = $ctx->config->{datasource}{connector}{job}
             // $ctx->config->{datasource}{connector};
@@ -39,7 +39,7 @@ sub instance {
         my %obj = (teng => $teng);
         return bless \%obj, $class;
     }->();
-    return $JOB;
+    return $DATASOURCE;
 }
 
 sub gets {

--- a/lib/App/Koyomi/DataSource/Job/Teng.pm
+++ b/lib/App/Koyomi/DataSource/Job/Teng.pm
@@ -176,6 +176,33 @@ sub update_by_id {
     return 1;
 }
 
+sub delete_by_id {
+    args(
+        my $self,
+        my $id   => 'Int',
+    );
+    my $teng = $self->teng;
+
+    # Transaction
+    my $txn = $teng->txn_scope;
+
+    eval {
+        unless ($teng->delete('jobs', +{ id => $id })) {
+            croakf(q/Delete jobs Failed! id=%d/, $id);
+        }
+        unless ($teng->delete('job_times', +{ job_id => $id })) {
+            croakf(q/Delete job_times Failed! id=%d/, $id);
+        }
+    };
+    if ($@) {
+        $txn->rollback;
+        die $@;
+    }
+
+    $txn->commit;
+    return 1;
+}
+
 1;
 
 __END__

--- a/lib/App/Koyomi/DataSource/Semaphore/Teng.pm
+++ b/lib/App/Koyomi/DataSource/Semaphore/Teng.pm
@@ -16,14 +16,14 @@ use parent qw(App::Koyomi::DataSource::Semaphore);
 
 use version; our $VERSION = 'v0.3.2';
 
-my $SEMAPHORE;
+my $DATASOURCE;
 
 sub instance {
     args(
         my $class,
         my $ctx => 'App::Koyomi::Context',
     );
-    $SEMAPHORE //= sub {
+    $DATASOURCE //= sub {
         my $connector
             = $ctx->config->{datasource}{connector}{semaphore}
             // $ctx->config->{datasource}{connector};
@@ -37,7 +37,7 @@ sub instance {
         my %obj = (teng => $teng);
         return bless \%obj, $class;
     }->();
-    return $SEMAPHORE;
+    return $DATASOURCE;
 }
 
 sub get_by_job_id {

--- a/script/koyomi-cli
+++ b/script/koyomi-cli
@@ -36,6 +36,9 @@ B<koyomi-cli> - Koyomi CLI for job's CRUD
     # Modify one Job
     koyomi-cli modify -id <job_id> [-e <PATH of EDITOR>]
 
+    # Delete one Job
+    koyomi-cli delete -id <job_id>
+
     # Show help and manual
     koyomi-cli help
     koyomi-cli man

--- a/script/koyomi-cli
+++ b/script/koyomi-cli
@@ -36,6 +36,10 @@ B<koyomi-cli> - Koyomi CLI for job's CRUD
     # Modify one Job
     koyomi-cli modify -id <job_id> [-e <PATH of EDITOR>]
 
+    # Show help and manual
+    koyomi-cli help
+    koyomi-cli man
+
 =head1 DESCRIPTION
 
 CommandLine Interface for CRUD of jobs.

--- a/script/koyomi-cli
+++ b/script/koyomi-cli
@@ -9,19 +9,13 @@ use version; our $VERSION = 'v0.3.2';
 
 use App::Koyomi::CLI;
 
-MAIN: {
-    main() if __FILE__ eq $0;
-}
+my ($method, $props, $args) = App::Koyomi::CLI->parse_args(@ARGV);
 
-sub main {
-    my ($method, $props, $args) = App::Koyomi::CLI->parse_args(@ARGV);
+pod2usage() unless $method;
+pod2usage(-verbose => 1) if $method eq 'help';
+pod2usage(-verbose => 2) if $method eq 'man';
 
-    pod2usage() unless $method;
-    pod2usage(-verbose => 1) if $method eq 'help';
-    pod2usage(-verbose => 2) if $method eq 'man';
-
-    App::Koyomi::CLI->new(%$props)->$method(%$args);
-}
+App::Koyomi::CLI->new(%$props)->$method(%$args);
 
 __END__
 


### PR DESCRIPTION
Now complete CRUD of jobs by **koyomi-cli**.
And a few improvements:

- Add description for YAML format on "add" and "delete" sub-commands of _koyomi-cli_.
- Show diff before update jobs when "koyomi-cli modify"

And a few minor changes.