### PR TITLE
FIX: Create and Delete semaphores record along with Jobs' creation/deletion.

### DIFF
--- a/lib/App/Koyomi/CLI.pm
+++ b/lib/App/Koyomi/CLI.pm
@@ -200,7 +200,7 @@ sub delete {
         return;
     }
 
-    $ctx->datasource_job->delete_by_id(id => $job_id);
+    $ctx->datasource_job->delete_by_id(id => $job_id, ctx => $ctx);
 
     infof('[delete] Finished.');
 }

--- a/lib/App/Koyomi/DataSource/Semaphore.pm
+++ b/lib/App/Koyomi/DataSource/Semaphore.pm
@@ -7,9 +7,10 @@ use Carp qw(croak);
 
 use version; our $VERSION = 'v0.4.0';
 
-sub instance { croak 'Must implement in child class!'; }
-
-sub get_by_job_id { croak 'Must implement in child class!'; }
+sub instance         { croak 'Must implement in child class!'; }
+sub get_by_job_id    { croak 'Must implement in child class!'; }
+sub create           { croak 'Must implement in child class!'; }
+sub delete_by_job_id { croak 'Must implement in child class!'; }
 
 1;
 
@@ -28,6 +29,8 @@ B<App::Koyomi::DataSource::Semaphore> - Abstract datasource class for semaphore 
     # Your implementation goes below
     sub instance { ... }
     sub get_by_job_id { ... }
+    sub create { ... }
+    sub delete_by_job_id { ... }
 
 =head1 DESCRIPTION
 
@@ -45,6 +48,14 @@ Probably it's singleton.
 =item B<get_by_job_id>
 
 Fetch one semaphore by job_id.
+
+=item B<create>
+
+Create a semaphore.
+
+=item B<delete_by_job_id>
+
+Delete one semaphore specified by job_id.
 
 =back
 

--- a/lib/App/Koyomi/DataSource/Semaphore.pm
+++ b/lib/App/Koyomi/DataSource/Semaphore.pm
@@ -27,6 +27,7 @@ B<App::Koyomi::DataSource::Semaphore> - Abstract datasource class for semaphore 
 
     # Your implementation goes below
     sub instance { ... }
+    sub get_by_job_id { ... }
 
 =head1 DESCRIPTION
 
@@ -40,6 +41,10 @@ Abstract datasource class for koyomi semaphore entity.
 
 Construct datasource object.
 Probably it's singleton.
+
+=item B<get_by_job_id>
+
+Fetch one semaphore by job_id.
 
 =back
 

--- a/lib/App/Koyomi/DataSource/Semaphore/Teng.pm
+++ b/lib/App/Koyomi/DataSource/Semaphore/Teng.pm
@@ -16,6 +16,7 @@ use parent qw(App::Koyomi::DataSource::Semaphore);
 
 use version; our $VERSION = 'v0.4.0';
 
+my $TABLE = 'semaphores';
 my $DATASOURCE;
 
 sub instance {
@@ -46,7 +47,7 @@ sub get_by_job_id {
         my $job_id => 'Int',
         my $ctx    => 'App::Koyomi::Context',
     );
-    my $row = $self->teng->single('semaphores', +{job_id => $job_id});
+    my $row = $self->teng->single($TABLE, +{job_id => $job_id});
     return unless $row;
     return App::Koyomi::DataSource::Semaphore::Teng::Data->new(
         row => $row,

--- a/schema/koyomi.ddl
+++ b/schema/koyomi.ddl
@@ -83,10 +83,10 @@ DROP TABLE IF EXISTS `semaphores`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `semaphores` (
   `job_id` int(10) unsigned NOT NULL COMMENT 'jobs.id',
-  `number` smallint(5) unsigned NOT NULL COMMENT 'Semaphore resource remains (Not in use)',
+  `number` smallint(5) unsigned NOT NULL DEFAULT '0' COMMENT 'Semaphore resource remains (Not in use)',
   `run_host` varchar(256) NOT NULL DEFAULT '' COMMENT 'On which host the last job ran',
   `run_pid` int(10) unsigned NOT NULL DEFAULT '0' COMMENT 'Tha last process id',
-  `run_date` datetime NOT NULL,
+  `run_date` datetime NOT NULL DEFAULT '1970-01-01 00:00:00',
   `created_on` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   PRIMARY KEY (`job_id`)


### PR DESCRIPTION
Currently, we need to create _semaphores_ record along with _jobs_ creation. Otherwise _koyomi worker_ can't execute the job.
And the _semaphores_ record should be deleted when the job is deleted.