### PR TITLE
Add --config|-c, --debug|-d options for koyomi-cli

### DIFF
--- a/lib/App/Koyomi/CLI.pm
+++ b/lib/App/Koyomi/CLI.pm
@@ -25,8 +25,14 @@ use version; our $VERSION = 'v0.5.0';
 my @CLI_METHODS = qw/help man add list modify delete/;
 
 sub new {
-    my $class = shift;
-    my %args  = @_;
+    args(
+        my $class,
+        my $config => +{ isa => 'Str',  optional => 1 },
+        my $debug  => +{ isa => 'Bool', optional => 1 },
+    );
+    $ENV{KOYOMI_CONFIG_PATH} = $config if $config;
+    $ENV{KOYOMI_LOG_DEBUG}   = 1       if $debug;
+
     my $ctx   = App::Koyomi::Context->instance;
     return bless +{ ctx => $ctx }, $class;
 }
@@ -42,14 +48,17 @@ sub parse_args {
     }
 
     Getopt::Long::GetOptionsFromArray(
-        \@args,         \my %opt,
-        'job-id|id=i', 'editor|e=s',
+        \@args, \my %opt, 'config|c=s',
+        'job-id|id=i', 'editor|e=s', 'debug|d'
     );
     my %cmd_args;
     $cmd_args{job_id} = $opt{'job-id'} if $opt{'job-id'};
     $cmd_args{editor} = $opt{editor}   if $opt{editor};
 
     my %property = ();
+    for my $key (qw/config debug/) {
+        $property{$key} = $opt{$key} if $opt{$key};
+    }
     return ($method, \%property, \%cmd_args);
 }
 

--- a/script/koyomi-cli
+++ b/script/koyomi-cli
@@ -28,16 +28,16 @@ B<koyomi-cli> - Koyomi CLI for job's CRUD
 =head1 SYNOPSIS
 
     # Add one Job
-    koyomi-cli add [-e <PATH of EDITOR>]
+    koyomi-cli add [OPTION] [-e <PATH of EDITOR>]
 
     # List Jobs
-    koyomi-cli list
+    koyomi-cli list [OPTION]
 
     # Modify one Job
-    koyomi-cli modify -id <job_id> [-e <PATH of EDITOR>]
+    koyomi-cli modify -id <job_id> [OPTION] [-e <PATH of EDITOR>]
 
     # Delete one Job
-    koyomi-cli delete -id <job_id>
+    koyomi-cli delete -id <job_id> [OPTION]
 
     # Show help and manual
     koyomi-cli help
@@ -46,6 +46,33 @@ B<koyomi-cli> - Koyomi CLI for job's CRUD
 =head1 DESCRIPTION
 
 CommandLine Interface for CRUD of jobs.
+
+=head1 OPTIONS
+
+=over 4
+
+=item B<--config|-c Str>
+
+Config file path.
+Can be specified with all CRUD sub-commands.
+
+=item B<--job-id|-id Int>
+
+Job ID.
+Must be specified with I<modify> and I<delete> sub-commands.
+
+=item B<--editor|-e Str>
+
+Path to executable file as text editor.
+Can be specified with I<add> and I<modify> sub-commands.
+Default is "vi".
+
+=item B<--debug|-d>
+
+Enable debug logging.
+Can be specified with all CRUD sub-commands.
+
+=back
 
 =head1 SEE ALSO
 


### PR DESCRIPTION
Add options for `koyomi-cli`:

- `--config|-c /path/to/config.toml`
- `--debug|-d` to enable debug logging

They are the same options introduced for `koyomi` in #10 .